### PR TITLE
Correct return type of I2SCamera::dmaBufferInit

### DIFF
--- a/I2SCamera.cpp
+++ b/I2SCamera.cpp
@@ -201,7 +201,7 @@ bool I2SCamera::i2sInit(const int VSYNC, const int HREF, const int PCLK, const i
     return true;
 }
 
-bool I2SCamera::dmaBufferInit(int bytes)
+void I2SCamera::dmaBufferInit(int bytes)
 {
   dmaBufferCount = 2;
   dmaBuffer = (DMABuffer**) malloc(sizeof(DMABuffer*) * dmaBufferCount);

--- a/I2SCamera.h
+++ b/I2SCamera.h
@@ -82,7 +82,7 @@ class I2SCamera
   static void i2sStop();
   static void i2sRun();
 
-  static bool dmaBufferInit(int bytes);
+  static void dmaBufferInit(int bytes);
   static void dmaBufferDeinit();
 
   static bool initVSync(int pin);


### PR DESCRIPTION
Lack of return statement in this function was causing compilation to fail:
```
C:\Users\per\AppData\Local\Temp\arduino_build_111040\sketch\I2SCamera.cpp: In static member function 'static bool I2SCamera::dmaBufferInit(int)':
I2SCamera.cpp:215: error: no return statement in function returning non-void [-Werror=return-type]

 }
 ^

cc1plus.exe: some warnings being treated as errors
```