### PR TITLE
typo

### DIFF
--- a/ESP32_I2S_Camera/OV7670.cpp
+++ b/ESP32_I2S_Camera/OV7670.cpp
@@ -73,7 +73,7 @@ void OV7670::frameControl(int hStart, int hStop, int vStart, int vStop)
 void OV7670::QQQVGA()
 {
     i2c.writeRegister(ADDR, REG_COM3, 0x04);  //DCW enable
-    i2c.writeRegister(ADDR, REG_COM14, 0x1b); //pixel clock divided by 4, manual scaling enable, DCW and PCLK controlled by register
+    i2c.writeRegister(ADDR, REG_COM14, 0x1b); //pixel clock divided by 8, manual scaling enable, DCW and PCLK controlled by register
     i2c.writeRegister(ADDR, REG_SCALING_XSC, 0x3a);
     i2c.writeRegister(ADDR, REG_SCALING_YSC, 0x35);
     i2c.writeRegister(ADDR, REG_SCALING_DCWCTR, 0x33); //downsample by 8


### PR DESCRIPTION
Small typo, confused me for a bit (which made me read the implementation guide better)

Relevant docs:
![image](https://user-images.githubusercontent.com/302821/39660528-92ff12f8-5041-11e8-9cb2-a1abfe1b53ef.png)

So full explanation for those reading along:
0x1b = 0b 0001 1011

bit[4] is set to set DCW and PCLK controlled by register
bit[3] is set to set manual scaling enable
bit[2:0] is set to 011 to divide by 8